### PR TITLE
will update to support latest dfp API versions

### DIFF
--- a/src/main/java/eu/adlogix/com/google/api/ads/dfp/domain/DfpVersion.java
+++ b/src/main/java/eu/adlogix/com/google/api/ads/dfp/domain/DfpVersion.java
@@ -2,7 +2,7 @@ package eu.adlogix.com.google.api.ads.dfp.domain;
 
 public enum DfpVersion {
 
-	V_201608("v201608"), V_201611("v201611"), V_201702("v201702");
+	V_201702("v201702"), V_201705("v201705"), V_201708("v201708");
 
 	String versionName;
 

--- a/src/main/java/eu/adlogix/com/google/api/ads/dfp/v201705/DfpFinderFactory.java
+++ b/src/main/java/eu/adlogix/com/google/api/ads/dfp/v201705/DfpFinderFactory.java
@@ -1,11 +1,11 @@
-package eu.adlogix.com.google.api.ads.dfp.v201611;
+package eu.adlogix.com.google.api.ads.dfp.v201705;
 
 import com.google.api.ads.dfp.axis.factory.DfpServices;
-import com.google.api.ads.dfp.axis.utils.v201611.StatementBuilder;
-import com.google.api.ads.dfp.axis.v201611.AdUnit;
-import com.google.api.ads.dfp.axis.v201611.LineItem;
-import com.google.api.ads.dfp.axis.v201611.Order;
-import com.google.api.ads.dfp.axis.v201611.Placement;
+import com.google.api.ads.dfp.axis.utils.v201705.StatementBuilder;
+import com.google.api.ads.dfp.axis.v201705.AdUnit;
+import com.google.api.ads.dfp.axis.v201705.LineItem;
+import com.google.api.ads.dfp.axis.v201705.Order;
+import com.google.api.ads.dfp.axis.v201705.Placement;
 import com.google.api.ads.dfp.lib.client.DfpSession;
 
 import eu.adlogix.com.google.api.ads.dfp.AdUnitFinder;
@@ -16,7 +16,7 @@ import eu.adlogix.com.google.api.ads.dfp.domain.DfpVersion;
 
 public class DfpFinderFactory {
 
-	private final DfpVersion VERSION = DfpVersion.V_201611;
+	private final DfpVersion VERSION = DfpVersion.V_201705;
 
 	private AdUnitFinder<AdUnit, StatementBuilder> adUnitFinder;
 

--- a/src/main/java/eu/adlogix/com/google/api/ads/dfp/v201705/DfpStatementBuilderCreatorFactory.java
+++ b/src/main/java/eu/adlogix/com/google/api/ads/dfp/v201705/DfpStatementBuilderCreatorFactory.java
@@ -1,6 +1,6 @@
-package eu.adlogix.com.google.api.ads.dfp.v201611;
+package eu.adlogix.com.google.api.ads.dfp.v201705;
 
-import com.google.api.ads.dfp.axis.utils.v201611.StatementBuilder;
+import com.google.api.ads.dfp.axis.utils.v201705.StatementBuilder;
 
 import eu.adlogix.com.google.api.ads.dfp.BaseStatementBuilderCreatorFactory;
 import eu.adlogix.com.google.api.ads.dfp.domain.DfpVersion;
@@ -8,7 +8,7 @@ import eu.adlogix.com.google.api.ads.dfp.domain.DfpVersion;
 public class DfpStatementBuilderCreatorFactory extends BaseStatementBuilderCreatorFactory<StatementBuilder> {
 
 	public DfpStatementBuilderCreatorFactory() {
-		super(DfpVersion.V_201611);
+		super(DfpVersion.V_201705);
 	}
 
 }

--- a/src/main/java/eu/adlogix/com/google/api/ads/dfp/v201708/DfpFinderFactory.java
+++ b/src/main/java/eu/adlogix/com/google/api/ads/dfp/v201708/DfpFinderFactory.java
@@ -1,11 +1,11 @@
-package eu.adlogix.com.google.api.ads.dfp.v201608;
+package eu.adlogix.com.google.api.ads.dfp.v201708;
 
 import com.google.api.ads.dfp.axis.factory.DfpServices;
-import com.google.api.ads.dfp.axis.utils.v201608.StatementBuilder;
-import com.google.api.ads.dfp.axis.v201608.AdUnit;
-import com.google.api.ads.dfp.axis.v201608.LineItem;
-import com.google.api.ads.dfp.axis.v201608.Order;
-import com.google.api.ads.dfp.axis.v201608.Placement;
+import com.google.api.ads.dfp.axis.utils.v201708.StatementBuilder;
+import com.google.api.ads.dfp.axis.v201708.AdUnit;
+import com.google.api.ads.dfp.axis.v201708.LineItem;
+import com.google.api.ads.dfp.axis.v201708.Order;
+import com.google.api.ads.dfp.axis.v201708.Placement;
 import com.google.api.ads.dfp.lib.client.DfpSession;
 
 import eu.adlogix.com.google.api.ads.dfp.AdUnitFinder;
@@ -16,7 +16,7 @@ import eu.adlogix.com.google.api.ads.dfp.domain.DfpVersion;
 
 public class DfpFinderFactory {
 
-	private final DfpVersion VERSION = DfpVersion.V_201608;
+	private final DfpVersion VERSION = DfpVersion.V_201708;
 
 	private AdUnitFinder<AdUnit, StatementBuilder> adUnitFinder;
 

--- a/src/main/java/eu/adlogix/com/google/api/ads/dfp/v201708/DfpStatementBuilderCreatorFactory.java
+++ b/src/main/java/eu/adlogix/com/google/api/ads/dfp/v201708/DfpStatementBuilderCreatorFactory.java
@@ -1,6 +1,6 @@
-package eu.adlogix.com.google.api.ads.dfp.v201608;
+package eu.adlogix.com.google.api.ads.dfp.v201708;
 
-import com.google.api.ads.dfp.axis.utils.v201608.StatementBuilder;
+import com.google.api.ads.dfp.axis.utils.v201708.StatementBuilder;
 
 import eu.adlogix.com.google.api.ads.dfp.BaseStatementBuilderCreatorFactory;
 import eu.adlogix.com.google.api.ads.dfp.domain.DfpVersion;
@@ -8,7 +8,7 @@ import eu.adlogix.com.google.api.ads.dfp.domain.DfpVersion;
 public class DfpStatementBuilderCreatorFactory extends BaseStatementBuilderCreatorFactory<StatementBuilder> {
 
 	public DfpStatementBuilderCreatorFactory() {
-		super(DfpVersion.V_201608);
+		super(DfpVersion.V_201708);
 	}
 
 }

--- a/src/test/java/eu/adlogix/com/google/api/ads/dfp/AdUnitStatementBuilderCreatorTest.java
+++ b/src/test/java/eu/adlogix/com/google/api/ads/dfp/AdUnitStatementBuilderCreatorTest.java
@@ -6,8 +6,8 @@ import org.testng.AssertJUnit;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import com.google.api.ads.dfp.axis.utils.v201702.StatementBuilder;
-import com.google.api.ads.dfp.axis.v201702.Statement;
+import com.google.api.ads.dfp.axis.utils.v201708.StatementBuilder;
+import com.google.api.ads.dfp.axis.v201708.Statement;
 
 import eu.adlogix.com.google.api.ads.dfp.domain.DfpVersion;
 
@@ -34,15 +34,15 @@ public class AdUnitStatementBuilderCreatorTest {
 	}
 
 	private AdUnitStatementBuilderCreator<StatementBuilder> providerItem_withId_equal() {
-		return new AdUnitStatementBuilderCreator<StatementBuilder>(DfpVersion.V_201702).withId("test_id", StatementCondition.EQUAL);
+		return new AdUnitStatementBuilderCreator<StatementBuilder>(DfpVersion.V_201708).withId("test_id", StatementCondition.EQUAL);
 	}
 
 	private AdUnitStatementBuilderCreator<StatementBuilder> providerItem_withId_not_equal() {
-		return new AdUnitStatementBuilderCreator<StatementBuilder>(DfpVersion.V_201702).withId("test_id", StatementCondition.NOT_EQUAL);
+		return new AdUnitStatementBuilderCreator<StatementBuilder>(DfpVersion.V_201708).withId("test_id", StatementCondition.NOT_EQUAL);
 	}
 
 	private AdUnitStatementBuilderCreator<StatementBuilder> providerItem_withIds() {
-		return new AdUnitStatementBuilderCreator<StatementBuilder>(DfpVersion.V_201702).withIds(Arrays.asList(new String[] {
+		return new AdUnitStatementBuilderCreator<StatementBuilder>(DfpVersion.V_201708).withIds(Arrays.asList(new String[] {
 				"Hello", "World" }));
 	}
 }


### PR DESCRIPTION
Added support for latest versions ("v201708", "v201705") and removed support for older versions ("v201608", "v201611") which are now deprecated.